### PR TITLE
chore: align react packages with expo

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,10 +10,10 @@
       "dependencies": {
         "expo": "^53.0.20",
         "expo-status-bar": "~2.2.3",
-        "react": "19.1.1",
-        "react-dom": "19.1.1",
-        "react-native": "0.80.2",
-        "react-native-web": "~0.21.0"
+        "react": "19.0.0",
+        "react-dom": "19.0.0",
+        "react-native": "0.79.5",
+        "react-native-web": "^0.20.0"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -3122,9 +3122,9 @@
       }
     },
     "node_modules/@react-native/assets-registry": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.80.2.tgz",
-      "integrity": "sha512-+sI2zIM22amhkZqW+RpD3qDoopeRiezrTtZMP+Y3HI+6/2JbEq7DdyV/2YS1lrSSdyy3STW2V37Lt4dKqP0lEQ==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.79.5.tgz",
+      "integrity": "sha512-N4Kt1cKxO5zgM/BLiyzuuDNquZPiIgfktEQ6TqJ/4nKA8zr4e8KJgU6Tb2eleihDO4E24HmkvGc73naybKRz/w==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3237,18 +3237,18 @@
       }
     },
     "node_modules/@react-native/community-cli-plugin": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.80.2.tgz",
-      "integrity": "sha512-UBjsE+lv1YtThs56mgFaUdWv0jNE1oO58Lkbf3dn47F0e7YiTubIcvP6AnlaMhZF2Pmt9ky8J1jTpgItO9tGeg==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.79.5.tgz",
+      "integrity": "sha512-ApLO1ARS8JnQglqS3JAHk0jrvB+zNW3dvNJyXPZPoygBpZVbf8sjvqeBiaEYpn8ETbFWddebC4HoQelDndnrrA==",
       "license": "MIT",
       "dependencies": {
-        "@react-native/dev-middleware": "0.80.2",
+        "@react-native/dev-middleware": "0.79.5",
         "chalk": "^4.0.0",
-        "debug": "^4.4.0",
+        "debug": "^2.2.0",
         "invariant": "^2.2.4",
-        "metro": "^0.82.2",
-        "metro-config": "^0.82.2",
-        "metro-core": "^0.82.2",
+        "metro": "^0.82.0",
+        "metro-config": "^0.82.0",
+        "metro-core": "^0.82.0",
         "semver": "^7.1.3"
       },
       "engines": {
@@ -3263,52 +3263,20 @@
         }
       }
     },
-    "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/debugger-frontend": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.80.2.tgz",
-      "integrity": "sha512-n3D88bqNk0bY+YjNxbM6giqva06xj+rgEfu91Pg+nJ0szSL2eLl7ULERJqI3hxFt0XGuTpTOxZgw/Po5maXa4g==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/dev-middleware": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.80.2.tgz",
-      "integrity": "sha512-8OeBEZNiApdbZaqTrrzeyFwXn/JwgJox7jdtjVAH56DggTVJXdbnyUjQ4ts6XAacEQgpFOAskoO730eyafOkAA==",
+    "node_modules/@react-native/community-cli-plugin/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
-        "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.80.2",
-        "chrome-launcher": "^0.15.2",
-        "chromium-edge-launcher": "^0.2.0",
-        "connect": "^3.6.5",
-        "debug": "^4.4.0",
-        "invariant": "^2.2.4",
-        "nullthrows": "^1.1.1",
-        "open": "^7.0.3",
-        "serve-static": "^1.16.2",
-        "ws": "^6.2.3"
-      },
-      "engines": {
-        "node": ">=18"
+        "ms": "2.0.0"
       }
     },
-    "node_modules/@react-native/community-cli-plugin/node_modules/open": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
-      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0",
-        "is-wsl": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+    "node_modules/@react-native/community-cli-plugin/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/semver": {
       "version": "7.7.2",
@@ -3320,15 +3288,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@react-native/community-cli-plugin/node_modules/ws": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
-      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
-      "license": "MIT",
-      "dependencies": {
-        "async-limiter": "~1.0.0"
       }
     },
     "node_modules/@react-native/debugger-frontend": {
@@ -3403,18 +3362,18 @@
       }
     },
     "node_modules/@react-native/gradle-plugin": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.80.2.tgz",
-      "integrity": "sha512-C5/FYbIfCXPFjF/hIcWFKC9rEadDDhPMbxE7tarGR9tmYKyb9o7fYvfNe8fFgbCRKelMHP0ShATz3T73pHHDfA==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.79.5.tgz",
+      "integrity": "sha512-K3QhfFNKiWKF3HsCZCEoWwJPSMcPJQaeqOmzFP4RL8L3nkpgUwn74PfSCcKHxooVpS6bMvJFQOz7ggUZtNVT+A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/js-polyfills": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.80.2.tgz",
-      "integrity": "sha512-f63M3paxHK92p6L9o+AY7hV/YojCZAhb+fdDpSfOtDtCngWbBhd6foJrO6IybzDFERxlwErupUg3pqr5w3KJWw==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.79.5.tgz",
+      "integrity": "sha512-a2wsFlIhvd9ZqCD5KPRsbCQmbZi6KxhRN++jrqG0FUTEV5vY7MvjjUqDILwJd2ZBZsf7uiDuClCcKqA+EEdbvw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3425,29 +3384,6 @@
       "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.5.tgz",
       "integrity": "sha512-nGXMNMclZgzLUxijQQ38Dm3IAEhgxuySAWQHnljFtfB0JdaMwpe0Ox9H7Tp2OgrEA+EMEv+Od9ElKlHwGKmmvQ==",
       "license": "MIT"
-    },
-    "node_modules/@react-native/virtualized-lists": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.80.2.tgz",
-      "integrity": "sha512-kXsIV2eB73QClbbH/z/lRhZkyj3Dke4tarM5w2yXSNwJthMPMfj4KqLZ6Lnf0nmPPjz7qo/voKtlrGqlM822Rg==",
-      "license": "MIT",
-      "dependencies": {
-        "invariant": "^2.2.4",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/react": "^19.0.0",
-        "react": "*",
-        "react-native": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -5704,36 +5640,6 @@
         "fsevents": "^2.3.2"
       }
     },
-    "node_modules/jest-haste-map/node_modules/jest-worker": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-util": "^29.7.0",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-haste-map/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/jest-message-util": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
@@ -5835,6 +5741,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/jimp-compact": {
@@ -6491,36 +6427,6 @@
         "node": ">=18.18"
       }
     },
-    "node_modules/metro-file-map/node_modules/jest-worker": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-util": "^29.7.0",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/metro-file-map/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/metro-minify-terser": {
       "version": "0.82.5",
       "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.82.5.tgz",
@@ -6660,36 +6566,6 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "license": "MIT"
-    },
-    "node_modules/metro/node_modules/jest-worker": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-util": "^29.7.0",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/metro/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
     },
     "node_modules/metro/node_modules/ws": {
       "version": "7.5.10",
@@ -7420,9 +7296,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
-      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7460,15 +7336,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
-      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
+      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.26.0"
+        "scheduler": "^0.25.0"
       },
       "peerDependencies": {
-        "react": "^19.1.1"
+        "react": "^19.0.0"
       }
     },
     "node_modules/react-is": {
@@ -7478,41 +7354,42 @@
       "license": "MIT"
     },
     "node_modules/react-native": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.80.2.tgz",
-      "integrity": "sha512-6ySV4qTJo/To3lgpG/9Mcg/ZtvExqOVZuT7JVGcO5rS2Bjvl/yUAkQF0hTnbRb2Ch6T5MlKghrM4OeHX+KA9Pg==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.79.5.tgz",
+      "integrity": "sha512-jVihwsE4mWEHZ9HkO1J2eUZSwHyDByZOqthwnGrVZCh6kTQBCm4v8dicsyDa6p0fpWNE5KicTcpX/XXl0ASJFg==",
       "license": "MIT",
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
-        "@react-native/assets-registry": "0.80.2",
-        "@react-native/codegen": "0.80.2",
-        "@react-native/community-cli-plugin": "0.80.2",
-        "@react-native/gradle-plugin": "0.80.2",
-        "@react-native/js-polyfills": "0.80.2",
-        "@react-native/normalize-colors": "0.80.2",
-        "@react-native/virtualized-lists": "0.80.2",
+        "@react-native/assets-registry": "0.79.5",
+        "@react-native/codegen": "0.79.5",
+        "@react-native/community-cli-plugin": "0.79.5",
+        "@react-native/gradle-plugin": "0.79.5",
+        "@react-native/js-polyfills": "0.79.5",
+        "@react-native/normalize-colors": "0.79.5",
+        "@react-native/virtualized-lists": "0.79.5",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
         "babel-jest": "^29.7.0",
-        "babel-plugin-syntax-hermes-parser": "0.28.1",
+        "babel-plugin-syntax-hermes-parser": "0.25.1",
         "base64-js": "^1.5.1",
         "chalk": "^4.0.0",
         "commander": "^12.0.0",
+        "event-target-shim": "^5.0.1",
         "flow-enums-runtime": "^0.0.6",
         "glob": "^7.1.1",
         "invariant": "^2.2.4",
         "jest-environment-node": "^29.7.0",
         "memoize-one": "^5.0.0",
-        "metro-runtime": "^0.82.2",
-        "metro-source-map": "^0.82.2",
+        "metro-runtime": "^0.82.0",
+        "metro-source-map": "^0.82.0",
         "nullthrows": "^1.1.1",
         "pretty-format": "^29.7.0",
         "promise": "^8.3.0",
         "react-devtools-core": "^6.1.1",
         "react-refresh": "^0.14.0",
         "regenerator-runtime": "^0.13.2",
-        "scheduler": "0.26.0",
+        "scheduler": "0.25.0",
         "semver": "^7.1.3",
         "stacktrace-parser": "^0.1.10",
         "whatwg-fetch": "^3.0.0",
@@ -7526,8 +7403,8 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@types/react": "^19.1.0",
-        "react": "^19.1.0"
+        "@types/react": "^19.0.0",
+        "react": "^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -7556,9 +7433,9 @@
       }
     },
     "node_modules/react-native-web": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.0.tgz",
-      "integrity": "sha512-S0mtV7wMPeet1kCRnrEmo1bTUJeFsKebleCbRwbBRBUg/BWS64bfsnnm+ArC+QtjlbZFSZmtvv8imzOIuOOa3Q==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.20.0.tgz",
+      "integrity": "sha512-OOSgrw+aON6R3hRosCau/xVxdLzbjEcsLysYedka0ZON4ZZe6n9xgeN9ZkoejhARM36oTlUgHIQqxGutEJ9Wxg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
@@ -7587,38 +7464,27 @@
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
       "license": "MIT"
     },
-    "node_modules/react-native/node_modules/@react-native/codegen": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.80.2.tgz",
-      "integrity": "sha512-eYad9ex9/RS6oFbbpu6LxsczktbhfJbJlTvtRlcWLJjJbFTeNr5Q7CgBT2/m5VtpxnJ/0YdmZ9vdazsJ2yp9kw==",
+    "node_modules/react-native/node_modules/@react-native/virtualized-lists": {
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.79.5.tgz",
+      "integrity": "sha512-EUPM2rfGNO4cbI3olAbhPkIt3q7MapwCwAJBzUfWlZ/pu0PRNOnMQ1IvaXTf3TpeozXV52K1OdprLEI/kI5eUA==",
       "license": "MIT",
       "dependencies": {
-        "glob": "^7.1.1",
-        "hermes-parser": "0.28.1",
         "invariant": "^2.2.4",
-        "nullthrows": "^1.1.1",
-        "yargs": "^17.6.2"
+        "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@babel/core": "*"
-      }
-    },
-    "node_modules/react-native/node_modules/@react-native/normalize-colors": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.80.2.tgz",
-      "integrity": "sha512-08Ax7554Z31NXi5SQ6h1GsiSrlZEOYHQNSC7u+x91Tdiq87IXldW8Ib1N3ThXoDcD8bjr+I+MdlabEJw36/fFg==",
-      "license": "MIT"
-    },
-    "node_modules/react-native/node_modules/babel-plugin-syntax-hermes-parser": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.28.1.tgz",
-      "integrity": "sha512-meT17DOuUElMNsL5LZN56d+KBp22hb0EfxWfuPUeoSi54e40v1W4C2V36P75FpsH9fVEfDKpw5Nnkahc8haSsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "hermes-parser": "0.28.1"
+        "@types/react": "^19.0.0",
+        "react": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native/node_modules/commander": {
@@ -7628,21 +7494,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/react-native/node_modules/hermes-estree": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.28.1.tgz",
-      "integrity": "sha512-w3nxl/RGM7LBae0v8LH2o36+8VqwOZGv9rX1wyoWT6YaKZLqpJZ0YQ5P0LVr3tuRpf7vCx0iIG4i/VmBJejxTQ==",
-      "license": "MIT"
-    },
-    "node_modules/react-native/node_modules/hermes-parser": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.28.1.tgz",
-      "integrity": "sha512-nf8o+hE8g7UJWParnccljHumE9Vlq8F7MqIdeahl+4x0tvCUJYRrT0L7h0MMg/X9YJmkNwsfbaNNrzPtFXOscg==",
-      "license": "MIT",
-      "dependencies": {
-        "hermes-estree": "0.28.1"
       }
     },
     "node_modules/react-native/node_modules/promise": {
@@ -7895,9 +7746,9 @@
       "license": "ISC"
     },
     "node_modules/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
       "license": "MIT"
     },
     "node_modules/semver": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,9 +12,9 @@
   "dependencies": {
     "expo": "^53.0.20",
     "expo-status-bar": "~2.2.3",
-    "react": "19.1.1",
-    "react-dom": "19.1.1",
-    "react-native": "0.80.2",
-    "react-native-web": "~0.21.0"
+    "react": "19.0.0",
+    "react-dom": "19.0.0",
+    "react-native": "0.79.5",
+    "react-native-web": "^0.20.0"
   }
 }


### PR DESCRIPTION
## Summary
- downgrade react, react-dom, react-native, and react-native-web to versions compatible with Expo 53

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_689417f3655883218f4beec0902759f8