### PR TITLE
Switch Babel config to react-native-worklets plugin

### DIFF
--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -2,6 +2,6 @@ module.exports = function(api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['nativewind/babel'],
+    plugins: ['nativewind/babel', 'react-native-worklets/plugin'],
   };
 };


### PR DESCRIPTION
## Summary
- use react-native-worklets/plugin instead of deprecated react-native-reanimated/plugin

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_689644ba4ae48321b9a577689209ce11