### PR TITLE
chore: disable reanimated babel plugin

### DIFF
--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -1,11 +1,19 @@
 module.exports = function(api) {
   api.cache(true);
   return {
-    presets: ['babel-preset-expo'],
+    presets: [
+      [
+        'babel-preset-expo',
+        {
+          // Disable auto-adding the deprecated Reanimated plugin
+          reanimated: false,
+        },
+      ],
+    ],
     plugins: [
       'nativewind/babel',
       // React Native Worklets plugin must come last
-      require.resolve('react-native-worklets/plugin'),
+      'react-native-worklets/plugin',
     ],
   };
 };


### PR DESCRIPTION
## Summary
- disable deprecated Reanimated plugin in Babel config
- use new react-native-worklets Babel plugin

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68973db1e840832185a3542e9aa1a022