### PR TITLE
chore: sync expo compatible packages

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,17 +9,17 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/metro-runtime": "~3.1.3",
-        "@react-native-picker/picker": "^2.4.8",
+        "@react-native-picker/picker": "2.6.1",
         "@react-navigation/native": "^6.1.9",
         "@react-navigation/stack": "^6.3.28",
         "expo": "~50.0.10",
-        "expo-status-bar": "~1.9.0",
+        "expo-status-bar": "~1.11.1",
         "nativewind": "^2.0.11",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-native": "0.73.6",
-        "react-native-safe-area-context": "^4.8.0",
-        "react-native-screens": "^3.20.0",
+        "react-native-safe-area-context": "4.8.2",
+        "react-native-screens": "~3.29.0",
         "react-native-web": "~0.19.6"
       }
     },
@@ -4838,16 +4838,13 @@
       }
     },
     "node_modules/@react-native-picker/picker": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.11.1.tgz",
-      "integrity": "sha512-ThklnkK4fV3yynnIIRBkxxjxR4IFbdMNJVF6tlLdOJ/zEFUEFUEdXY0KmH0iYzMwY8W4/InWsLiA7AkpAbnexA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.6.1.tgz",
+      "integrity": "sha512-oJftvmLOj6Y6/bF4kPcK6L83yNBALGmqNYugf94BzP0FQGpHBwimVN2ygqkQ2Sn2ZU3pGUZMs0jV6+Gku2GyYg==",
       "license": "MIT",
-      "workspaces": [
-        "example"
-      ],
       "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
+        "react": ">=16",
+        "react-native": ">=0.57"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -7873,9 +7870,9 @@
       }
     },
     "node_modules/expo-status-bar": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-1.9.0.tgz",
-      "integrity": "sha512-5vx9dgWT59opYTndnnF3b7vEfvEJinCywrAPEQaXT7gtDzssARy/7fzaWF8Cyg8SqbGUn8nU/UtgnCc1fqLnAA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-1.11.1.tgz",
+      "integrity": "sha512-ddQEtCOgYHTLlFUe/yH67dDBIoct5VIULthyT3LRJbEwdpzAgueKsX2FYK02ldh440V87PWKCamh7R9evk1rrg==",
       "license": "MIT"
     },
     "node_modules/exponential-backoff": {
@@ -12528,9 +12525,9 @@
       }
     },
     "node_modules/react-native-safe-area-context": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.14.1.tgz",
-      "integrity": "sha512-+tUhT5WBl8nh5+P+chYhAjR470iCByf9z5EYdCEbPaAK3Yfzw+o8VRPnUgmPAKlSccOgQBxx3NOl/Wzckn9ujg==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.8.2.tgz",
+      "integrity": "sha512-ffUOv8BJQ6RqO3nLml5gxJ6ab3EestPiyWekxdzO/1MQ7NF8fW1Mzh1C5QE9yq573Xefnc7FuzGXjtesZGv7cQ==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",
@@ -12538,9 +12535,9 @@
       }
     },
     "node_modules/react-native-screens": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-3.37.0.tgz",
-      "integrity": "sha512-vEi4qZqWYoGuVGuHTv1K2XA90rgSydksmR5+tb5uhL93whl6Bch6EEXzC+8eEfj4SimiCgXBPY7r/xTXJxvnUg==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-3.29.0.tgz",
+      "integrity": "sha512-yB1GoAMamFAcYf4ku94uBPn0/ani9QG7NdI98beJ5cet2YFESYYzuEIuU+kt+CNRcO8qqKeugxlfgAa3HyTqlg==",
       "license": "MIT",
       "dependencies": {
         "react-freeze": "^1.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,16 +10,16 @@
     "test": "echo \"No tests specified\" && exit 0"
   },
   "dependencies": {
-    "@react-native-picker/picker": "^2.4.8",
+    "@react-native-picker/picker": "2.6.1",
     "@react-navigation/native": "^6.1.9",
     "@react-navigation/stack": "^6.3.28",
     "expo": "~50.0.10",
-    "expo-status-bar": "~1.9.0",
+    "expo-status-bar": "~1.11.1",
     "nativewind": "^2.0.11",
     "react": "18.2.0",
     "react-native": "0.73.6",
-    "react-native-safe-area-context": "^4.8.0",
-    "react-native-screens": "^3.20.0",
+    "react-native-safe-area-context": "4.8.2",
+    "react-native-screens": "~3.29.0",
     "react-native-web": "~0.19.6",
     "react-dom": "18.2.0",
     "@expo/metro-runtime": "~3.1.3"


### PR DESCRIPTION
## Summary
- align picker and status-bar dependencies with Expo 50 requirements
- fix safe area and screens packages for compatibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897738e2eac8321b9ed0a6df0bd8923